### PR TITLE
Fix NRE in Soil.cs when Dynamic Fire System is the fire extension

### DIFF
--- a/src/Soil.cs
+++ b/src/Soil.cs
@@ -725,12 +725,13 @@ namespace Landis.Extension.Succession.ForC
             {
                 if (tmpFireSeverity == 0)   //usual case
                 {
-                    System.Diagnostics.Debug.Assert(SiteVars.FireSeverity != null);
+                    if (SiteVars.FireSeverity == null)
+                        SiteVars.FireSeverity = PlugIn.ModelCore.GetSiteVar<byte>("Fire.Severity");
+                    if (SiteVars.FireSeverity == null)
+                        return;  // no fire extension loaded; nothing to do
                     severity = SiteVars.FireSeverity[site];
                     if (severity == 0)
-                        SiteVars.FireSeverity = PlugIn.ModelCore.GetSiteVar<byte>("Fire.Severity");
-                    if (severity == 0)
-                        return;     //no impacts from a fire severity = 0
+                        return;
                 }
                 else
                 {   //called during spin-up


### PR DESCRIPTION
## Summary

ForCS-Succession crashes with a `NullReferenceException` at `Soil.cs:729` the first time fire damages a cohort under **Dynamic Fire System** (`Extension-Dynamic-Fire-System`).
The crash does **not** occur under Base Fire — only Dynamic Fire is affected.

## Root cause

`Soil.DisturbanceImpactsBiomass()` dereferences `SiteVars.FireSeverity[site]` directly:

```csharp
// Soil.cs:729 (current)
severity = SiteVars.FireSeverity[site];
```

`SiteVars.FireSeverity` is populated by `SiteVars.Initialize() → GetSiteVar<byte>("Fire.Severity")`, which is called from `PlugIn.Initialize()`.
Under Base Fire this works because Base Fire registers `"Fire.Severity"` early enough that ForCS sees it at init time.

Under Dynamic Fire System, registration order is different: ForCS init runs before Dynamic Fire publishes `"Fire.Severity"` to the SiteVarHub, so `SiteVars.FireSeverity` is `null` when the first fire event triggers `DisturbanceImpactsBiomass()`.
Result: NRE on the first fire, simulation aborts.

There is a `null`-fallback further down in the same method (`severity = 0`), but it lives *after* the null-deref, so it can never run.

## Fix

Lazy-initialise `SiteVars.FireSeverity` immediately before the lookup, and gracefully no-op when no fire extension is loaded:

```csharp
// Soil.cs (patched)
if (SiteVars.FireSeverity == null)
    SiteVars.FireSeverity = PlugIn.ModelCore.GetSiteVar<byte>("Fire.Severity");

if (SiteVars.FireSeverity == null)
    return;  // no fire extension loaded - nothing to do

severity = SiteVars.FireSeverity[site];
if (severity == 0)
    return;
```

This preserves the original semantics under Base Fire (where the lookup succeeds at init time, so the lazy branch is a no-op) and additionally handles the Dynamic Fire ordering case and the no-fire case.

## Validation

Tested as the succession extension in a 100×100-m ICH landscape (~10⁶ active cells) with Dynamic Fire System + Dynamic Fuel System on a DEoptim calibration:

- **~9,900 LANDIS-II sims** (110 DEoptim iterations × 90 candidates ×
  10 reps, 10-year sims, fire-active landscape)
- **0 NRE crashes** at `Soil.cs:729`
- Carbon-pool transfers and severity binning all execute as expected

Prior to the patch the same configuration aborted on the very first trial.

## Notes

- Patch is minimally invasive — three lines added, no semantic change to the existing Base Fire path.
- No new public API; no test changes required (although it would be worth adding tests that include different fire extensions).
